### PR TITLE
Added a .htaccess to hide the .git directory on the public website

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+RedirectMatch 404 "(?:.*)/(?:\.git|file_or_dir)(?:/.*)?$"


### PR DESCRIPTION
The .git directory was visible on the public website. I fixed this potential vulnerability by adding a .htaccess file with a rule that prevents this directory from being accessed. (More info about that here: http://biasedbit.com/hide-git-folder-with-htaccess/)
